### PR TITLE
Partie encodage des données ajoutée

### DIFF
--- a/timgan.py
+++ b/timgan.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import json
+from sklearn.preprocessing import LabelEncoder
 
 def load_concatenate_json_files(folder_path):
     # Initialiser une liste vide pour stocker les DataFrames
@@ -51,5 +52,44 @@ df = load_concatenate_json_files(folder_path)
 
 # Appel de la fonction pour simplifier les données des actors
 df = simplify_df(df)
+
+# Partie encocodage de données 
+
+# Apply integer encoding to 'Verb' and 'Object' columns
+label_encoder_actor = LabelEncoder()
+label_encoder_verb = LabelEncoder()
+label_encoder_object = LabelEncoder()
+df['Actor'] = label_encoder_actor.fit_transform(df['Actor'])
+df['Verb'] = label_encoder_verb.fit_transform(df['Verb'])
+df['Object'] = label_encoder_object.fit_transform(df['Object'])
+
+# Convert the 'Timestamp' column to datetime objects
+df['Timestamp'] = pd.to_datetime(df['Timestamp'])
+
+# Convert datetime timestamps to seconds since the epoch using .timestamp()
+df['Timestamp'] = df['Timestamp'].apply(lambda x: x.timestamp())
+
+# Find the earliest timestamp in seconds since the epoch
+min_timestamp_seconds = df['Timestamp'].min()
+
+# Calculate the difference in seconds from the first event
+df['Timestamp'] = df['Timestamp'] - min_timestamp_seconds
+
+# Sort the DataFrame by the 'Timestamp' column
+df_sorted = df.sort_values(by='Timestamp')
+
+# Reset the index of the sorted DataFrame to get a new index that represents the chronological order
+df_sorted = df_sorted.reset_index(drop=True)
+
+# Add the 'Chronological_Order' column at the first position (index 0)
+df_sorted.insert(0, 'Chronological_Order', df_sorted.index + 1)  # Adding 1 so that the order starts from 1 instead of 0
+
+df = df_sorted
+
+# The dataframe is now preprocessed and ready for synthetic data generation
+df_preprocessed_shape = df.shape
+df_preprocessed_head = df.head()
+
+df_preprocessed_shape, df_preprocessed_head
 
 df


### PR DESCRIPTION
J'ai fais en sorte que les actors, verbs et objects soient tous encodés en tant qu'integer. J'ai transformé les timestamps en un format plus adapté. Maintenant, le formatage est en seconde et prend en référence le timestamp le plus ancien. Par ex	 le premier est à 0 seconde, le deuxième à 4, le troisième à 7 etc. J'ai rajouté une colonne Chronological_Order qui donne la place chronologique de chaque timestamp. Attention, le df est maintenant dans l'ordre chronologique donc il faut bien penser à le mélangé pour le training.